### PR TITLE
Setup dsfr

### DIFF
--- a/cnr/settings.py
+++ b/cnr/settings.py
@@ -42,6 +42,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    "widget_tweaks",
+    "dsfr",
     'public_website',
 ]
 
@@ -60,7 +62,10 @@ ROOT_URLCONF = 'cnr.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, "dsfr/templates"),
+            os.path.join(BASE_DIR, "templates"),
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -72,6 +77,8 @@ TEMPLATES = [
         },
     },
 ]
+
+FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 WSGI_APPLICATION = 'cnr.wsgi.application'
 

--- a/public_website/templates/public_website/index.html
+++ b/public_website/templates/public_website/index.html
@@ -1,1 +1,5 @@
-<h1>Hello world</h1>
+{% extends 'base.html' %}
+
+{% block content %}
+<h1>Une nouvelle méthode pour construire ensemble et au plus près du terrain l'avenir de la France</h1>
+{% endblock content %}

--- a/public_website/tests/test_index.py
+++ b/public_website/tests/test_index.py
@@ -15,3 +15,11 @@ class TestIndex(TestCase):
     def test_index_response_contains_welcome_message(self):
         response = self.client.get("/")
         self.assertContains(response, "Une nouvelle méthode")
+
+
+class TestDSFR(TestCase):
+
+    def test_dsfr_is_loaded(self):
+        response = self.client.get('/')
+        dsfr_proof = '<link rel="stylesheet" href="/static/dsfr/dist/utility/icons/icons.css">'
+        self.assertContains(response, dsfr_proof)

--- a/public_website/tests/test_index.py
+++ b/public_website/tests/test_index.py
@@ -14,4 +14,4 @@ class TestIndex(TestCase):
 
     def test_index_response_contains_welcome_message(self):
         response = self.client.get("/")
-        self.assertContains(response, "Hello world")
+        self.assertContains(response, "Une nouvelle méthode")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django==3.2.15
 psycopg2-binary==2.9.3
 python-dotenv==0.21.0
+django-widget-tweaks==1.4.12
+django-dsfr==0.9.0

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,9 +13,9 @@
   {% block title %}
   <title>
     {% if title %}
-      {{ title }} — Design Système de l’État
+      {{ title }} — Conseil National de la Refondation
     {% else %}
-      Design Système de l’État
+      Conseil National de la Refondation
     {% endif %}
   </title>
   {% endblock title %}
@@ -34,8 +34,6 @@
         {% block content %}{% endblock content %}
       </main>
     </div>
-
-
 
   {% dsfr_js %}
   {% block extra_js %}{% endblock extra_js %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,44 @@
+{% load static dsfr_tags %}
+<!doctype html>
+<html lang="fr" data-fr-scheme="system" {% if SITE_CONFIG.mourning %}data-fr-mourning{% endif %}>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+
+  {% dsfr_css %}
+  {% dsfr_favicon %}
+  {% block extra_css %}{% endblock extra_css %}
+
+  {% block title %}
+  <title>
+    {% if title %}
+      {{ title }} — Design Système de l’État
+    {% else %}
+      Design Système de l’État
+    {% endif %}
+  </title>
+  {% endblock title %}
+</head>
+
+<body>
+    {% block skiplinks %}
+        {% dsfr_skiplinks skiplinks %}
+    {% endblock skiplinks %}
+
+    {% include "blocks/header.html" %}
+    {% dsfr_theme_modale %}
+
+    <div class="fr-container fr-mt-4w fr-mb-6w">
+      <main id="content" role="main">
+        {% block content %}{% endblock content %}
+      </main>
+    </div>
+
+
+
+  {% dsfr_js %}
+  {% block extra_js %}{% endblock extra_js %}
+</body>
+
+</html>

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -1,0 +1,19 @@
+{% extends "dsfr/header.html" %}
+
+{% block service_title %}
+<a href="/" title="Accueil — CNR">
+    <p class="fr-header__service-title">CNR</p>
+</a>
+{% endblock service_title %}
+
+{% block service_tagline %}Conseil National de la Refondation{% endblock service_tagline %}
+
+{% block header_tools %}
+{% endblock header_tools %}
+
+{# Leave burger_menu and main_menu blocks empty if the main menu is not used #}
+{# block burger_menu #}
+{# endblock burger_menu #}
+
+{% block main_menu %}
+{% endblock main_menu %}


### PR DESCRIPTION
Setup du DSFR en utilisant l'app [Django-DSFR](https://github.com/entrepreneur-interet-general/django-dsfr).
Création du template `base.html` et du `header.html`

> Seul le dernier commit concerne cette PR - on est reparties de la PR#2 pour avoir la page d'accueil

<img width="1245" alt="Capture d’écran 2022-09-14 à 17 47 47" src="https://user-images.githubusercontent.com/6756627/190201913-b44907e3-3df9-4761-96b9-f1d5ff6da42d.png">
