### PR TITLE
add possiblity multiple hosts allowed

### DIFF
--- a/cnr/settings.py
+++ b/cnr/settings.py
@@ -34,17 +34,18 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ["127.0.0.1", os.getenv("HOST_URL", "localhost")]
-
+ALLOWED_HOSTS = (
+    os.getenv("HOST_URL", "127.0.0.1, localhost").replace(" ", "").split(",")
+)
 
 # Application definition
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
     "django.forms",
     "widget_tweaks",
     "dsfr",


### PR DESCRIPTION
On veut parfois ajouter plusieurs hosts dans la variable d'env "HOST_URL" (par exemple: addresse-de-prod.scalingo.io, conseil-refondation.fr, www.conseil-refondation.fr, etc.)