### PR TITLE
Ajout d'un lien pour avoir plus de details sur les thématiques

### DIFF
--- a/public_website/templates/public_website/fonctionnement.html
+++ b/public_website/templates/public_website/fonctionnement.html
@@ -77,7 +77,7 @@
 
 <div class="fr-container fr-py-6w">
   <div class="fr-grid-row fr-grid-row--gutters">
-    <div class="fr-col-12">
+    <div class="fr-col-12" id="ancre_thematiques">
       <h2>Lancement du Conseil national de la Refondation</h2>
       <p>Jeudi 8 septembre, le Président de la République s'est rendu à Marcoussis, dans l’Essonne, pour le lancement du Conseil national de la Refondation en réunissant des représentants de forces politiques, des partenaires sociaux, des élus locaux, des représentants du monde économique et du monde associatif.</p>
       <p>Découvrez ici le témoignage de trois participants lors de cette journée :</p>

--- a/public_website/templates/public_website/index.html
+++ b/public_website/templates/public_website/index.html
@@ -170,6 +170,9 @@
       </div>
     </div>
 
+    <div class="fr-col-12">
+      <a href="{% url 'fonctionnement' %}#ancre_thematiques" target="_self" class="fr-link">Voir le détail des thématiques</a>
+    </div>
   </div>
 
   <hr class="fr-my-6w">


### PR DESCRIPTION
Ajout d'un lien avec une ancre pour avoir plus de details sur les thématiques "Voir le détail des thématiques".

/!\ Cette PR est en brouillon car on doit attendre le merge de la page "fonctionnement" qui fait apparaitre le bloc "thématiques"

<img width="569" alt="Capture d’écran 2022-09-19 à 17 41 21" src="https://user-images.githubusercontent.com/6756627/191057577-10f557b7-537e-4ea1-9862-5e6fca40819c.png">
