### PR TITLE
Ajouter le badge Beta dans le header

### DIFF
--- a/static/css/style.sass
+++ b/static/css/style.sass
@@ -6,3 +6,9 @@
 
 .illustration
   max-width: 300px
+
+// to align Logo CNR with Beta Badge in header
+.fr-header__service
+  display: flex
+  align-items: start
+  justify-content: center

--- a/templates/blocks/header.html
+++ b/templates/blocks/header.html
@@ -8,7 +8,8 @@
 {% endblock brand %}
 
 {% block service_title %}
-<img src="{% static 'images/cnr_logo_horizontal.svg' %}" alt="Logo du Conseil National de la Refondation" class="fr-responsive-img logo">
+  <img src="{% static 'images/cnr_logo_horizontal.svg' %}" alt="Logo du Conseil National de la Refondation" class="logo">
+  <span class="fr-badge fr-badge--sm fr-badge--blue-cumulus">Beta</span>
 {% endblock service_title %}
 
 {% block service_tagline %}


### PR DESCRIPTION
Ajouter le badge Beta dans le header.

<img width="557" alt="Capture d’écran 2022-09-22 à 15 57 23" src="https://user-images.githubusercontent.com/6756627/191766914-d1c95594-a6f7-4700-ae6f-d06656f8efe9.png">
