### PR TITLE
Accessibilité - ajout des liens d'evitement

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -52,9 +52,18 @@
 </head>
 
 <body>
-    {% block skiplinks %}
-        {% dsfr_skiplinks skiplinks %}
-    {% endblock skiplinks %}
+  <div class="fr-skiplinks">
+    <nav class="fr-container" role="navigation" aria-label="Accès rapide">
+      <ul class="fr-skiplinks__list">
+        <li>
+            <a class="fr-link" href="#content">Accéder au contenu</a>
+        </li>
+        <li>
+            <a class="fr-link" href="#footer">Accéder au pied de page</a>
+        </li>
+      </ul>
+    </nav>
+</div>
 
     {% include "blocks/header.html" %}
     {% dsfr_theme_modale %}


### PR DESCRIPTION
Accessibilité - ajout des liens d'evitement. Pour accéder plus rapidement au contenu et au footer.

<img width="1246" alt="Capture d’écran 2022-09-23 à 15 13 51" src="https://user-images.githubusercontent.com/6756627/191968303-e4ce5a58-2d74-4689-bfdb-64c22df01128.png">
