### PR TITLE
add uuid to session after successful profile update / profile already complete

### DIFF
--- a/public_website/tests/test_forms.py
+++ b/public_website/tests/test_forms.py
@@ -73,16 +73,16 @@ class ProfileForm(TestCase):
     @patch_send_in_blue
     def test_submit_successfully(self):
         response = self.generate_response()
-        # FIXME because there is no UUID, the /participation-intro/ redirects on index
-        self.assertIsNone(self.client.session.get("uuid", None))
-        self.assertRedirects(response, "/")
+        participant = Participant.objects.last()
+        self.assertEqual(self.client.session.get("uuid"), str(participant.uuid))
+        self.assertRedirects(response, "/participation-intro/")
 
     @patch_send_in_blue
     def test_submit_successfully_several_interests(self):
         response = self.generate_response("preferred_themes", ["EDUCATION", "SANTE"])
-        # FIXME because there is no UUID, the /participation-intro/ redirects on index
-        self.assertIsNone(self.client.session.get("uuid", None))
-        self.assertRedirects(response, "/")
+        participant = Participant.objects.last()
+        self.assertEqual(self.client.session.get("uuid"), str(participant.uuid))
+        self.assertRedirects(response, "/participation-intro/")
 
     def test_fails_without_consent(self):
         response = self.generate_response("gives_gdpr_consent", None)
@@ -112,20 +112,22 @@ class ProfileForm(TestCase):
     @patch_send_in_blue
     def test_returning_user_gets_confirmation_form_message(self):
         self.generate_response()
-        self.assertTrue(
-            Participant.objects.filter(email="prudence.crandall@educ.gouv.fr").exists()
-        )
+        participant = Participant.objects.filter(email="prudence.crandall@educ.gouv.fr")
+        self.assertTrue(participant.exists())
+
         response = self.generate_response()
-        # FIXME because there is no UUID, the /participation-intro/ redirects on index
-        self.assertIsNone(self.client.session.get("uuid", None))
-        self.assertRedirects(response, "/")
+        still_participant = Participant.objects.last()
+        self.assertEqual(participant[0].id, still_participant.id)
+
+        self.assertEqual(self.client.session.get("uuid"), str(still_participant.uuid))
+        self.assertRedirects(response, "/participation-intro/")
 
     @patch_send_in_blue
     def test_99_validates_for_postal_code(self):
         response = self.generate_response("postal_code", "99")
-        # FIXME because there is no UUID, the /participation-intro/ redirects on index
-        self.assertIsNone(self.client.session.get("uuid", None))
-        self.assertRedirects(response, "/")
+        participant = Participant.objects.last()
+        self.assertEqual(self.client.session.get("uuid"), str(participant.uuid))
+        self.assertRedirects(response, "/participation-intro/")
 
     def test_98_does_not_validates_for_postal_code(self):
         response = self.generate_response("postal_code", "98")

--- a/public_website/views.py
+++ b/public_website/views.py
@@ -72,6 +72,7 @@ def inscription_view(request):
                         "Votre profil est déjà rempli. Il n'a pas été mis à jour."
                     )
                     messages.error(request, error_message)
+                    request.session["uuid"] = str(participant.uuid)
                     return redirect("survey_intro")
                 else:
                     form = ProfileForm(request.POST, instance=participant)
@@ -83,6 +84,7 @@ def inscription_view(request):
                 send_participant_profile_to_email_provider(participant)
             )
             participant.save()
+            request.session["uuid"] = str(participant.uuid)
             return redirect("survey_intro")
         else:
             form = ProfileForm(request.POST, initial=form.data)


### PR DESCRIPTION
Ajout de l'uuid dans la session quand on soumet un formulaire valide à ProfileForm. 

Fix des tests qui vérifiaient que le uuid était bien dispo (avant, ils étaient à None, maintenant ça vérifie réellement).

j'avais pas vu que pre-commit avait modifié les factories, pas de modif de ma part dans cette PR. 