### PR TITLE
Corrige le formulaire qui apparaissait deux fois

### DIFF
--- a/surveys/tests/test_views.py
+++ b/surveys/tests/test_views.py
@@ -16,9 +16,8 @@ class TestSurvey(TestCase):
         self.survey_1 = SurveyFactory(label="label_1")
         session = self.client.session
         session["uuid"] = str(self.current_participant.uuid)
-        session["surveys"] = ["label_1"]
-        session["survey_steps"] = 1
-        session["survey_current_step"] = 1
+        session["selected_surveys"] = ["label_1"]
+        session["survey_step"] = 1
         session.save()
 
     def test_survey_url_calls_right_view(self):
@@ -60,8 +59,7 @@ class TestSurveyView(TestCase):
         )
         self.survey_3 = SurveyFactory(theme=Theme.EDUCATION)
         self.survey_3_question_1 = SurveyQuestionFactory(
-            survey=self.survey_3,
-            hr_label="What do you think ?"
+            survey=self.survey_3, hr_label="What do you think ?"
         )
         self.survey_4 = SurveyFactory(theme=Theme.SANTE)
 
@@ -70,9 +68,8 @@ class TestSurveyView(TestCase):
 
         self.session = self.client.session
         self.session["uuid"] = str(self.known_participant.uuid)
-        self.session["surveys"] = ["survey_test_2", self.survey_3.label]
-        self.session["survey_steps"] = 2
-        self.session["survey_current_step"] = 1
+        self.session["selected_surveys"] = ["survey_test_2", self.survey_3.label]
+        self.session["survey_step"] = 1
         self.session.save()
 
     def test_survey_view_with_known_uuid_provided(self):
@@ -111,7 +108,6 @@ class TestSurveyView(TestCase):
         )
 
         self.assertContains(response_2, self.survey_3_question_1.hr_label)
-
 
 
 @tag("views")

--- a/surveys/views.py
+++ b/surveys/views.py
@@ -37,10 +37,8 @@ def survey_intro_view(request):
         form = forms.SelectSurveysForm(data=request.POST, surveys=surveys)
         if form.is_valid():
             selected_surveys = form.cleaned_data["surveys"]
-            request.session["surveys"] = selected_surveys
-            request.session["survey_steps"] = len(selected_surveys)
-            request.session["survey_current_step"] = 1
-
+            request.session["selected_surveys"] = selected_surveys
+            request.session["survey_step"] = 1
             request.session.save()
             return redirect("survey")
         else:
@@ -52,82 +50,94 @@ def survey_intro_view(request):
 
 
 def survey_view(request):
-    def get_current_next_surveys(selected_surveys: list, survey_step: int) -> tuple:
+    def format_request_session(session):
+        uuid = session.get("uuid", None)
+        selected_surveys = session.get("selected_surveys", None)
+        survey_step = session.get("survey_step", None)
+
+        for mandatory_attribute in [uuid, survey_step, selected_surveys]:
+            if not mandatory_attribute:
+                logger.info(f"### missing {mandatory_attribute}")
+                raise KeyError
+
         try:
-            current_label = selected_surveys[survey_step - 1]
+            participant = Participant.objects.get(uuid=uuid)
+        except Participant.DoesNotExist:
+            raise KeyError
+
+        return (selected_surveys, int(survey_step), participant)
+
+    def get_current_next_surveys(survey_list: list, step: int) -> tuple:
+        try:
+            current_label = survey_list[step - 1]
             current_survey = models.Survey.objects.get(label=current_label)
-            is_last_step = (len(selected_surveys) - survey_step) == 0
+            is_last_step = (len(survey_list) - step) == 0
             if is_last_step:
                 next_survey = None
             else:
-                next_survey_label = selected_surveys[survey_step]
+                next_survey_label = survey_list[step]
                 next_survey = models.Survey.objects.get(label=next_survey_label)
         except models.Survey.DoesNotExist:
             current_survey = None
 
         return (current_survey, next_survey)
 
-    uuid = request.session.get("uuid", None)
-    selected_surveys = request.session.get("surveys", None)
-    survey_current_step = request.session.get("survey_current_step", None)
+    def anonymize_and_save_answers(participant, valid_form):
+        for field_name, field_object in valid_form.fields.items():
+            answer = form.cleaned_data[field_name]
+            if answer:
+                rank = int(field_name.split("-")[-1])
+                models.SurveyAnswer(
+                    survey_question=models.SurveyQuestion.objects.get(
+                        label=field_object.label
+                    ),
+                    rank=rank,
+                    answer=answer,
+                    postal_code=participant.postal_code,
+                ).save()
 
-    for mandatory_attribute in [uuid, survey_current_step, selected_surveys]:
-        if not mandatory_attribute:
-            logger.info(f"### missing {mandatory_attribute}")
-            return redirect("survey_intro")
+        models.SurveyParticipation(
+            participant=participant, survey=current_survey
+        ).save()
 
     try:
-        current_participant = Participant.objects.get(uuid=request.session["uuid"])
-    except Participant.DoesNotExist:
-        return redirect("index")
+        selected_surveys, survey_step, participant = format_request_session(
+            request.session
+        )
+    except KeyError:
+        return redirect("survey_into")
 
     current_survey, next_survey = get_current_next_surveys(
-        selected_surveys, survey_current_step
+        selected_surveys, survey_step
     )
 
     if not current_survey:
         return redirect("participation-outro")
 
-    has_participated_before = current_survey in current_participant.participations.all()
+    has_participated_before = current_survey in participant.participations.all()
     if has_participated_before:
+        # TODO display this message is user tries to access
+        #  survey they already filled out
         return redirect(reverse("survey-intro"))
 
     if request.method == "POST":
         questions = current_survey.get_questions()
         form = forms.SurveyForm(request.POST, questions=questions)
         if form.is_valid():
-            for field_name, field_object in form.fields.items():
-                answer = form.cleaned_data[field_name]
-                if answer:
-                    rank = int(field_name.split("-")[-1])
-                    models.SurveyAnswer(
-                        survey_question=models.SurveyQuestion.objects.get(
-                            label=field_object.label
-                        ),
-                        rank=rank,
-                        answer=answer,
-                        postal_code=current_participant.postal_code,
-                    ).save()
+            anonymize_and_save_answers(participant, form)
 
-            models.SurveyParticipation(
-                participant=current_participant, survey=current_survey
-            ).save()
-            # TODO display this message is user tries to access
-            #  survey they already filled out
-            survey_current_step += 1
             if not next_survey:
                 return render(
                     request,
                     "surveys/survey_outro.html",
                 )
             else:
-                request.session["survey_current_step"] = survey_current_step
+                survey_step += 1
+                request.session["survey_step"] = survey_step
                 request.session.save()
                 current_survey, next_survey = get_current_next_surveys(
-                    selected_surveys, survey_current_step
+                    selected_surveys, survey_step
                 )
-                questions = current_survey.get_questions()
-
         else:
             error_message = "Formulaire invalide. Veuillez vérifier vos réponses."
             messages.error(request, error_message)
@@ -142,7 +152,7 @@ def survey_view(request):
             "form": form,
             "theme": current_survey.hr_label,
             "next_theme": next_theme,
-            "current_step": int(survey_current_step),
+            "current_step": int(survey_step),
             "steps": len(selected_surveys),
             "questions": questions,
         },


### PR DESCRIPTION
Avant cette PR, un utilisateur qui sélectionne les questionnaires "S_1" et "S_2" voyait apparaitre "S_1", puis "S_1, puis "S_2"

Avec cette PR, l'utilisateur voir "S_1" puis "S_2"

## implémentation

Refacto de la vue `surveys`