### PR TITLE
Retire le fichier requirements_for_test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -r requirements_for_test.txt
+          pip install -r requirements.txt
       - name: Copy empty .env.test to .env
         run: |
           cp .env.test .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ WORKDIR /app
 
 RUN python -m pip install --upgrade pip
 
-COPY requirements.txt requirements_for_test.txt .
-RUN pip install -r requirements_for_test.txt
+COPY requirements.txt requirements.txt .
+RUN pip install -r requirements.txt
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ python manage.py migrate
 D'abord installer les dépendances de test :
 
 ```sh
-pip install -r requirements_for_test.txt
+pip install -r requirements.txt
 ```
 
 Les tests unitaires peuvent être lancés avec `make test-units`, les

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ urllib3==1.26.12
 requests==2.28.1
 sib-api-v3-sdk==7.5.0
 factory-boy==3.2.1
+behave==1.2.6
+selenium==4.4.3
+behave-django==1.4.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,4 +1,0 @@
--r requirements.txt
-behave==1.2.6
-selenium==4.4.3
-behave-django==1.4.0


### PR DESCRIPTION
Le fait de ne pas avoir la dépendant de behave_django empêche le déploiement