### PR TITLE
Fix html pour enregistrer les réponses des participants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 RUN python -m pip install --upgrade pip
 
-COPY requirements.txt requirements.txt .
+COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 COPY . .

--- a/features/questionnaire.feature
+++ b/features/questionnaire.feature
@@ -1,0 +1,19 @@
+# language: fr
+
+Fonctionnalité: Questionnaire
+  Contexte:
+    Quand je me rends sur la page d'accueil
+    Et je clique sur "Participer"
+    Quand je remplis le champ "Prénom" avec "Micheline"
+    Et je remplis le champ "Adresse électronique" avec "micheline@france.org"
+    Et je remplis le champ "Code postal" avec "12345"
+    Et je choisis "Particulier" pour "Je suis :"
+    Et je choisis "Climat" pour "Les thématiques sur lesquelles je veux m'investir"
+    Et je coche la case "j'accepte les CGU"
+    Et je soumets le formulaire
+    Et je soumets le formulaire
+
+  Scénario: Je peux soumettre mes réponses
+    Quand je remplis toutes les questions du formulaire
+    Et je soumets le formulaire
+    Alors il existe une réponse "foobar"

--- a/features/steps/question_steps.py
+++ b/features/steps/question_steps.py
@@ -1,0 +1,7 @@
+from behave import *
+from selenium.webdriver.common.by import By
+from surveys.models import SurveyAnswer
+
+@then('il existe une réponse "{}"')
+def step_impl(context, answer):
+    assert SurveyAnswer.objects.last().answer == answer

--- a/features/steps/survey_steps.py
+++ b/features/steps/survey_steps.py
@@ -1,0 +1,9 @@
+from behave import *
+from selenium.webdriver.common.by import By
+
+@when('je remplis toutes les questions du formulaire')
+def step_impl(context):
+    inputs = context.browser.find_elements(By.XPATH, '//form//*[@type="text"]')
+
+    for input in inputs:
+        input.send_keys("foobar")

--- a/surveys/templates/surveys/survey.html
+++ b/surveys/templates/surveys/survey.html
@@ -29,7 +29,7 @@
                     {{ question.hr_label }}
                     {% for field in form %}
                         {% if field.label == question.label %}
-                            <input class="fr-input fr-mt-1w" type="text" name="{{ field.id_for_label }}" id="{{ field.id_for_label }}"></label>
+                          <input class="fr-input fr-mt-1w" type="text" name="{{ field.html_name }}" id="{{ field.id_for_label }}"></input>
                         {% endif %}
                     {% endfor %}
                 </div>


### PR DESCRIPTION
Lors du refactoring du HTML du questionnaire, nous avons perdu la possibilité de transmettre correctement les réponses au questionnaire.
Avec cette PR, nous pouvons de nouveau enregistrer les réponses.

A noter que : 
@freesteph a fait un super boulot avec cette PR et la mise en place des tests E2E
Les tests E2E fonctionnent en isolation mais se marchent sur les pieds quand on les joue l'un après l'autre.