### PR TITLE
e2e test for profile updated or unchanged

### DIFF
--- a/features/message_profil_inchange.feature
+++ b/features/message_profil_inchange.feature
@@ -1,0 +1,28 @@
+# language: fr
+
+Fonctionnalité: Formulaire d'inscription
+    Contexte:
+        Quand je me rends sur la page d'accueil
+        Et je clique sur "Participer"
+        Quand je remplis le champ "Prénom" avec "Micheline"
+        Et je remplis le champ "Adresse électronique" avec "micheline@france.org"
+        Et je remplis le champ "Code postal" avec "12345"
+        Et je choisis "Particulier" pour "Je suis :"
+        Et je choisis "Climat" pour "Les thématiques sur lesquelles je veux m'investir"
+        Et je coche la case "j'accepte les CGU"
+        Et je soumets le formulaire
+
+    Scénario: On me confirme mon inscription
+        Alors je peux lire "Votre inscription est enregistrée" dans la page
+
+    Scénario: Modifier le profil est impossible
+        Quand je clique sur "Participer"
+        Et je remplis le champ "Prénom" avec "Marie-Micheline"
+        Et je remplis le champ "Adresse électronique" avec "micheline@france.org"
+        Et je remplis le champ "Code postal" avec "54321"
+        Et je choisis "Particulier" pour "Je suis :"
+        Et je choisis "Climat" pour "Les thématiques sur lesquelles je veux m'investir"
+        Et je choisis "Santé" pour "Les thématiques sur lesquelles je veux m'investir"
+        Et je coche la case "j'accepte les CGU"
+        Et je soumets le formulaire
+        Alors je peux lire "Votre profil est déjà rempli. Il n'a pas été mis à jour" dans la page


### PR DESCRIPTION
Utilise le générateur de tests de behave. Vérifie que les messages de confirmation et de profil inchangé s'affichent correctement.