### PR TITLE
fix bug /participation/{label} : argument of type 'NoneType' is not iterable

### DIFF
--- a/surveys/views.py
+++ b/surveys/views.py
@@ -52,7 +52,7 @@ def survey_intro_view(request):
 def survey_view(request, label):
     def format_request_session(session, label):
         uuid = session.get("uuid", None)
-        selected_surveys = session.get("selected_surveys", None)
+        selected_surveys = session.get("selected_surveys", [])
         expected_label = label in selected_surveys
 
         for mandatory_attribute in [uuid, expected_label, selected_surveys]:


### PR DESCRIPTION
Il y avait une erreur 500 relevée par Sentry, si quelqu'un arrivait sur la page /participation/theme directement : cette PR permet de le régler