### PR TITLE
Utiliser la debug toolbar en debug

### DIFF
--- a/cnr/settings.py
+++ b/cnr/settings.py
@@ -60,14 +60,12 @@ INSTALLED_APPS = [
     "public_website",
     "surveys",
     "behave_django",
-    "debug_toolbar",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -75,6 +73,14 @@ MIDDLEWARE = [
     "django_referrer_policy.middleware.ReferrerPolicyMiddleware",
     "csp.middleware.CSPMiddleware",
 ]
+
+
+# Add debug toolbar
+if DEBUG:
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    INTERNAL_IPS = ["127.0.0.1"] + ALLOWED_HOSTS
+
 
 # Sentry
 SENTRY_URL = os.getenv("SENTRY_URL", "")


### PR DESCRIPTION
Avec cette PR, l'APP et le Middlware de la debug toolbar ne sont actif que lorsque debug == true