### PR TITLE
Fix enregistrement des thèmes

### DIFF
--- a/public_website/templates/public_website/inscription.html
+++ b/public_website/templates/public_website/inscription.html
@@ -98,7 +98,7 @@
                                 <div class="fr-fieldset__content">
                                     {% for theme in form.preferred_themes %}
                                     <div class="fr-checkbox-group">
-                                        <input type="checkbox" id="{{ theme.id_for_label }}" name="{{ theme.id_for_label }}">
+                                        {{ theme.tag }}
                                         <label class="fr-label" for="{{ theme.id_for_label }}">{{ theme.choice_label }}
                                         </label>
                                     </div>


### PR DESCRIPTION
Changement de l'input avec id = theme.id_for_label qui soumettait `id_preferred_themes_{0-9}` au lieu de preferred_themes. Retour à l'input généré automatiquement par Django. 

Fixes #213 

Co-authored-by: BenoitSerrano benoit.serrano10@gmail.com