### PR TITLE
Remplacer "nomdusite" par le nom du site dans la boîte à cookies

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -70,7 +70,7 @@
 <body>
 
   <div id="fr-consent-banner" class="fr-consent-banner fr-hidden">
-    <h2 class="fr-h6">À propos des cookies sur nomdusite.fr</h2>
+    <h2 class="fr-h6">À propos des cookies sur conseil-refondation.fr</h2>
     <div class="fr-consent-banner__content">
         <p class="fr-text--sm">Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et les services disponibles sur ce site. Pour en savoir plus, visitez la page <a href="{% url 'confidentialite' %}">Données personnelles et cookies</a>. Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.</p>
     </div>


### PR DESCRIPTION
# Objectif

Corriger la typo dans la boîte à cookies