### PR TITLE
Supprimer la génération de badge de la CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,26 +37,3 @@ jobs:
       - name: Run the e2e tests
         run: |
           make test-e2e
-      - name: Generate coverage badge
-        if: github.ref == 'refs/heads/main'
-        run: |
-          coverage run manage.py test --settings cnr.settings_test
-          
-          total=`coverage report | grep TOTAL | grep -Eo '[0-9]+%' | sed 's/%//'`
-          
-          if (( $(echo "$total <= 50" | bc -l) )) ; then
-            color=red
-          elif (( $(echo "$total > 85" | bc -l) )); then
-            color=green
-          else
-            color=orange
-          fi
-
-          curl https://img.shields.io/badge/coverage-$total%25-$color > ./coverage_badge.svg
-      - name: Add and commit changes
-        if: github.ref == 'refs/heads/main'
-        uses: EndBug/add-and-commit@v9.1.1
-        with:
-          author_name: "InfraBetaGouv"
-          author_email: "infra@beta.gouv.fr"
-          message: "chore: update coverage"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Pour les tests E2E, si vous n'utilisez pas Docker, il vous faudra
 accessibles sur votre machine pour lancer les tests E2E.  Sur MacOS,
 vous pouvez les installer via [brew](https://brew.sh/) avec la commande: `brew install geckodriver`.
 
+Vous pouvez également générer un rapport sur la couverture de tests :
+```sh 
+coverage run manage.py test --settings cnr.settings_test
+```
+
 ### via Docker
 
 #### Copier les variables d'environnement


### PR DESCRIPTION
# 🎯 Objectif

Supprimer la tâche de CI qui calculait le coverage et commitait à nouveau sur la branche main. La protection de la branche empêchait cette tâche de fonctionner correctement, ce qui empêchait le déploiement de main sur le staging.

# 🔍 Implémentation

- [x] Supprimer les tâches associées dans le fichier github actions
- [x] Ajouter dans le README la façon de calculer le coverage manuellement